### PR TITLE
Feature/7 a propos page

### DIFF
--- a/data/a-propos.md
+++ b/data/a-propos.md
@@ -2,6 +2,7 @@
 
 title: À Propos
 path: /a-propos
+order: 1
 
 ---
 
@@ -37,4 +38,6 @@ Ethics by design vous propose ainsi un fil de conférences en continu pendant 2 
 
 Tout comme lors des éditions 2017 et 2018 de l’évènement, nous vous proposons en parallèle de participer à la construction des services de demain en traitant ces thématiques avec le plus d’horizontalité possible à travers de nombreux formats participatifs, des classiques ateliers aux débats mouvants et fishbowls.
 
-Ce afin de permettre à ceux qui constituent le public traditionnellement hétérogène d’Ethics by design de pouvoir dialoguer entre eux : designers, studios, agences, universitaires, journalistes, chefs de projet et consultants. Alors, vous en êtes ?
+Ce afin de permettre à ceux qui constituent le public traditionnellement hétérogène d’Ethics by design de pouvoir dialoguer entre eux : designers, studios, agences, universitaires, journalistes, chefs de projet et consultants. 
+
+##Alors, vous en êtes ?

--- a/data/a-propos.md
+++ b/data/a-propos.md
@@ -5,3 +5,36 @@ path: /a-propos
 
 ---
 
+#Comment concevoir de façon responsable des services ou des produits numériques ?
+
+Telle est la question centrale que nous posons édition après édition à Ethics by design. Une question toujours centrale dans une année 2020 largement inédite tant par les évènements mondiaux que nous affrontons que par l’engouement général du monde de la conception numérique pour cette problématique.
+
+###Où en sommes-nous de la responsabilité dans la conception ?
+
+Ces dernières années ont fait émerger nombre de problématiques du conception plus ou moins inédites. La question de la privacy et du respect des données personnelles a longtemps été le principal angle par lequel la responsabilité a été abordée. L’accessibilité des services numériques est également un sujet historiquement abordé, notamment au sein de certaines communautés de développeurs.
+
+Récemment nous avons nous-même largement traité de la question du design de l’attention et du design persuasif. Et aujourd’hui, c’est la question environnementale qui est au coeur de la plupart des initiatives. Nous pourrions aussi mentionner le travail mené ces dernières années autour du rapport entre numérique et démocratie, ou celui entre numérique et société.
+
+Les champs de la conception responsable paraissent ainsi toujours plus nombreux, et les problématiques qu’ils soulèvent toujours plus importantes.
+
+###2020, une année charnière ?
+
+Face à cette explosion des champs de la conception responsable ; des initiatives associatives, universitaires, institutionnelles ou entrepreneuriales ; de la littérature autour de ces questions ; des initiatives étudiantes revendiquant une formation prenant en compte ces questions ; de la remise à l’honneur des textes et discours des pionniers de la technocritique et de la conception responsable ; n’assiste-t-on pas à un moment charnière de la conception en 2020 ? C’est en tout cas ce que nous appelons de nos voeux.
+
+Mais pour éviter l’écueil d’un énième coup d’épée dans l’eau ou d’une vision “ethics-washing” de la conception responsable, il nous semble nécessaire d’affirmer collectivement ce que doit être cette conception numérique responsable et durable. C’est précisément le sens Ethics by design 2020.
+
+###Ethics by design 2020 
+
+Après Lyon en 2017 et Paris en 2018, Ethics by design se déroulera en 2020 à Lille, à l’occasion de l'événement Lille Métropole 2020, Capitale Mondiale du Design. Il est organisé en partenariat avec la métropole de Lille et son comité d’organisation La République du design et la CCI Grand Lille qui accueille l’évènement au Palais de la Bourse.
+
+Sur 2 journées, il permettra à ses participants de s’interroger sur les manières dont le design peut être une pratique de redirection promovant la responsabilité au travers de la conception, de la stratégie, de l’économie : low tech, nouveaux modèles économiques des systèmes numériques, biens communs numériques ou encore plate-formisation de la société seront au coeur de ces deux journées.
+
+Nous vous proposons d’aborder cette problématique à travers 4 thématiques qui rythmeront nos deux journées d’échanges : conception environnementale responsable, formation et posture du designer, économie et entreprise responsable & politiques de l’innovation.
+
+###Interdisciplinarité et horizontalité
+
+Ethics by design vous propose ainsi un fil de conférences en continu pendant 2 jours permettant de traiter en profondeur nos thématiques via les prises de parole de designers, universitaires et personnalités de la société civile au travers d’un programme éditorial sans appel à participation.
+
+Tout comme lors des éditions 2017 et 2018 de l’évènement, nous vous proposons en parallèle de participer à la construction des services de demain en traitant ces thématiques avec le plus d’horizontalité possible à travers de nombreux formats participatifs, des classiques ateliers aux débats mouvants et fishbowls.
+
+Ce afin de permettre à ceux qui constituent le public traditionnellement hétérogène d’Ethics by design de pouvoir dialoguer entre eux : designers, studios, agences, universitaires, journalistes, chefs de projet et consultants. Alors, vous en êtes ?

--- a/data/designers-ethiques.md
+++ b/data/designers-ethiques.md
@@ -1,0 +1,18 @@
+---
+
+title: Les Designers Ethiques
+path: /a-propos
+order: 2
+
+---
+
+Designers Ethiques est une structure de recherche-action sur les questions de responsabilité, du numérique et du design.
+
+Il rassemble une communauté d’acteurs engagés - designers, développeurs, chercheurs, étudiants...- ayant à coeur d’explorer et participer à l’élaboration de pratiques plus vertueuses et respectueuses de l’utilisateur et de l’environnement.
+
+La structure, présente dans plusieurs villes de France au travers de ses antennes, s’organise autour de quatres actions pour penser et pratiquer avec responsabilité.
+
+**Explorer** - Par l’organisation de séminaires de recherche-action avec des experts en design, recherche, économie.<br /> 
+**Expérimenter** - Par le développement d’une boite à outil théorique et pratique pour les concepteurs rassemblmant écrits et méthodologies en creative commons.<br />
+**Former** - Par la collaboration avec des écoles de design, écoles de commerce mais aussi structure de formation pour professionnnels.<br />
+**Connecter** - Par l’organisation de l’événement Ethics By Design.

--- a/src/components/content-wrapper.js
+++ b/src/components/content-wrapper.js
@@ -1,0 +1,11 @@
+import React from "react"
+
+import style from "./content-wrapper.module.css"
+
+export default function ContentWrapper(props) {
+    return (
+        <div className={style.contentWrapper}>
+            <div dangerouslySetInnerHTML={{ __html: props.content }} />
+        </div>
+    )
+};

--- a/src/components/content-wrapper.module.css
+++ b/src/components/content-wrapper.module.css
@@ -13,3 +13,7 @@
 .contentWrapper div {
   max-width: 750px;
 }
+
+.contentWrapper h1 {
+  line-height: 30px;
+}

--- a/src/components/content-wrapper.module.css
+++ b/src/components/content-wrapper.module.css
@@ -1,0 +1,15 @@
+.contentWrapper {
+  font-family: Georgia, serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 15px;
+  line-height: 137.99%;
+
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.contentWrapper div {
+  max-width: 750px;
+}

--- a/src/pages/a-propos.js
+++ b/src/pages/a-propos.js
@@ -4,6 +4,7 @@ import { graphql } from "gatsby"
 import Layout from "../layouts/layout"
 import Section from "../components/section"
 import Title from "../components/title"
+import ContentWrapper from "../components/content-wrapper"
 
 export const query = graphql`
   query {
@@ -28,13 +29,14 @@ export const query = graphql`
 
 const APropos = ({ location, data }) => {
     console.log('a propos', data);
-    const aPropos = data.allMarkdownRemark.edges[0].node.frontmatter.title
+    const aPropos = data.allMarkdownRemark.edges[0].node.frontmatter;
+    const aProposContent = data.allMarkdownRemark.edges[0].node.html;
 
     return (
         <Layout location={location}>
-            <Title>{aPropos.title}</Title>
             <Section>
-                <Title />
+                <Title>{aPropos.title}</Title>
+                <ContentWrapper content={aProposContent} />
             </Section>
             <Section>
                 <Title />

--- a/src/pages/a-propos.js
+++ b/src/pages/a-propos.js
@@ -13,12 +13,16 @@ export const query = graphql`
         title
       }
     }
-    allMarkdownRemark(filter: {frontmatter: {path: {eq: "/a-propos"}}}) {
+    allMarkdownRemark(
+        filter: {frontmatter: {path: {eq: "/a-propos"}}},
+        sort: {fields: frontmatter___order, order: ASC }
+    ) {
         edges {
             node {
                 frontmatter {
                     path
                     title
+                    order
                 }
                 html
             }
@@ -28,19 +32,14 @@ export const query = graphql`
 `
 
 const APropos = ({ location, data }) => {
-    console.log('a propos', data);
-    const aPropos = data.allMarkdownRemark.edges[0].node.frontmatter;
-    const aProposContent = data.allMarkdownRemark.edges[0].node.html;
-
     return (
         <Layout location={location}>
-            <Section>
-                <Title>{aPropos.title}</Title>
-                <ContentWrapper content={aProposContent} />
-            </Section>
-            <Section>
-                <Title />
-            </Section>
+            {data.allMarkdownRemark.edges.map((edge) => {
+                return <Section key={edge.node.frontmatter.title}>
+                    <Title>{edge.node.frontmatter.title}</Title>
+                    <ContentWrapper content={edge.node.html} />
+                </Section>;
+            })}
         </Layout>
     );
 }


### PR DESCRIPTION
Added markdown pages for _A Propos_ and _Les Designers Ethiques_ texts of `A Propos` page
Render both markdowns on `A Propos` page
Added `ContentWrapper` style

![Screen Shot 2020-05-06 at 10 29 21](https://user-images.githubusercontent.com/8865258/81189382-7df6c200-8f84-11ea-807c-c87d9cc82173.png)

![Screen Shot 2020-05-06 at 10 29 28](https://user-images.githubusercontent.com/8865258/81189366-7a633b00-8f84-11ea-9e8c-a72d9268663f.png)
